### PR TITLE
Update mod.py

### DIFF
--- a/sangou/cogs/mod.py
+++ b/sangou/cogs/mod.py
@@ -825,7 +825,7 @@ class Mod(Cog):
         if ctx.guild.get_member(target.id):
             target = ctx.guild.get_member(target.id)
             if self.check_if_target_is_staff(target):
-                return await ctx.send("I cannot ban Staff members.")
+                return await ctx.send("I cannot warn Staff members.")
 
         if reason:
             warn_count = add_userlog(


### PR DESCRIPTION
Replaced String where the bot would falsely claim they were trying to ban a Staff member when trying to warn a staff member.

(I'm unsure if the restriction against warning staff is even required as I could see some actual use cases for this, but this at least makes the message more clear either way)